### PR TITLE
Не удалять запиненные сообщения

### DIFF
--- a/cleaner/admin.py
+++ b/cleaner/admin.py
@@ -6,7 +6,7 @@ class MessageAdmin(admin.ModelAdmin):
     list_display = (
         'message_id',
         'text',
-        'time_added',
+        'time_sent',
         'is_deleted',
         'error_count',
         'skip',

--- a/cleaner/models.py
+++ b/cleaner/models.py
@@ -1,15 +1,15 @@
 from django.db import models
-
+from django.utils import timezone
 
 class Message(models.Model):
     message_id = models.IntegerField(unique=True, verbose_name="Message ID")
     user_id = models.IntegerField(blank=True, null=True, verbose_name="User ID")
-    date = models.IntegerField(blank=True, null=True, verbose_name="Sent date")
+    time_sent = models.DateTimeField(default=timezone.now, verbose_name="Sent Date")
     text = models.TextField(blank=True, null=True, verbose_name="Text")
     time_added = models.DateTimeField(auto_now_add=True, verbose_name="Added to DB")
     is_deleted = models.BooleanField(default=False, verbose_name="Deleted?")
     error_count = models.IntegerField(default=0, verbose_name="Error count")
-    skip = models.BooleanField(default=False, verbose_name="Can't delete message")
+    skip = models.BooleanField(default=False, verbose_name="Skipped or Can't delete message")
 
     def __str__(self):
         return str(self.message_id)

--- a/cleaner/views.py
+++ b/cleaner/views.py
@@ -1,6 +1,8 @@
 import json
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.views.decorators.csrf import csrf_exempt
+from datetime import datetime
+from django.utils import timezone
 from mmtelegrambot.settings import MM_CHAT_ID, WEBHOOK_SECRET_TOKEN
 from .models import Message
 from youtuber.utils import escape_str, send_api_request
@@ -53,10 +55,16 @@ def telegram_bot(request):
                     date = update['message']['date']
                     text = update['message'].get('text')
 
+                    # Convert Unix timestamp to naive datetime in UTC
+                    time_sent = datetime.utcfromtimestamp(date)
+
+                    # Make the datetime aware in the local timezone
+                    time_sent = timezone.make_aware(time_sent)
+
                     message = Message(
                         message_id=message_id,
                         user_id=user_id,
-                        date=date,
+                        time_sent=time_sent,
                         text=text
                     )
 

--- a/cleaner/views.py
+++ b/cleaner/views.py
@@ -50,6 +50,14 @@ def telegram_bot(request):
                                 return HttpResponse('ok')
                             except:
                                 return HttpResponseBadRequest('Bad Request')
+                elif 'pinned_message' in update['message']:
+                    pinned_message_id = update['message']['pinned_message']['message_id']
+                    try:
+                        message = Message.objects.get(message_id=pinned_message_id)
+                        message.skip = True
+                        message.save()
+                    except Exception as e:
+                        print(f'Error while skipping pinned message {message_id}:\n {e}')
                 else:
                     user_id = update['message']['from']['id']
                     date = update['message']['date']


### PR DESCRIPTION
2 небольших обновления:

- Запиненные в чате сообщения теперь пропускаются при удалении старых сообщений
- Для фильтрации старых сообщений теперь используется дата отправки (ранее использовалась дата сохранения в БД)