### PR TITLE
fix: update yt-dlp version to fix audio download issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,5 +54,5 @@ tzdata==2023.3
 urllib3==2.0.4
 websockets==13.1
 Werkzeug==2.3.7
-yt-dlp==2025.8.11
+yt-dlp==2025.9.23
 zipp==3.16.2


### PR DESCRIPTION
Release notes: [yt-dlp 2025.09.23](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.09.23)